### PR TITLE
Assume yes also for apt-get install for aptcacher-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 To build Labriqueinter.net directly with [yunohost](https://yunohost.org/) we
 cannot use debootstrap with qemu-arm because mysql-server-5.5 is buggy and the
-installation failed. 
+installation failed.
 
 The best solution compiling the kernel and perform a debootstrap on an olimex
 board. This process take much time but it the best solution to build
-labriqueinter.net entirely with scripts. 
+labriqueinter.net entirely with scripts.
 
 ## How ?
 
@@ -35,12 +35,12 @@ cd /opt/build.labriqueinter.net && bash init.sh
 
 ```shell
 cd /opt/build.labriqueinter.net && bash build_labriqueinternet_lime.sh
-``` 
+```
 
 ### Create image file
 
 Partitioning on loop device seems not work on my board. So we should retrieve
-the tarball on your local machine and create device. 
+the tarball on your local machine and create device.
 
 On your computer:
 
@@ -50,7 +50,7 @@ scp root@myolimex:/srv/olinux/labriqueinternet_$(date "+%d-%m-%Y") .
 scp root@myolimex:/srv/olinux/sunxi/u-boot/u-boot-sunxi-with-spl.bin .
 sudo bash olinux/create_device.sh -d img -s 1400 -t labriqueinternet_$(date "+%d-%m-%Y").img -b ./yunohost_lime.tar -u ./u-boot-sunxi-with-spl.bin
 ```
- 
+
 ## Build with cross compilation and cross debootstrap
 
 /!\ Warning: with this method you cannot perform a debootstrap with yunohost

--- a/init.sh
+++ b/init.sh
@@ -13,15 +13,17 @@ export DEBCONF_NONINTERACTIVE_SEEN true
 export LANG C
 apt-get update
 
+apt='apt-get -o Dpkg::Options::=--force-confnew --force-yes -uy'
+
 # Install and configure apt proxy
 if [ ! -f /etc/apt/apt.conf.d/01proxy ] ; then
-  apt-get install apt-cacher-ng
+  $apt install apt-cacher-ng
   echo Acquire::http::Proxy "http://localhost:3142"; >> \
    /etc/apt/apt.conf.d/01proxy
 fi
 
 # Install packages for kernel and u-boot compilation
-apt-get install --force-yes -y gcc-4.7 ncurses-dev uboot-mkimage \
+$apt install gcc-4.7 ncurses-dev uboot-mkimage \
  build-essential vim libusb-1.0-0-dev pkg-config bc netpbm debootstrap dpkg-dev
 
 # Clone repository for image creation

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 set -e
 set -x
@@ -13,9 +13,9 @@ export DEBCONF_NONINTERACTIVE_SEEN true
 export LANG C
 apt-get update
 
-# Install and configure apt proxy 
+# Install and configure apt proxy
 if [ ! -f /etc/apt/apt.conf.d/01proxy ] ; then
-  apt-get install apt-cacher-ng 
+  apt-get install apt-cacher-ng
   echo Acquire::http::Proxy "http://localhost:3142"; >> \
    /etc/apt/apt.conf.d/01proxy
 fi
@@ -24,5 +24,5 @@ fi
 apt-get install --force-yes -y gcc-4.7 ncurses-dev uboot-mkimage \
  build-essential vim libusb-1.0-0-dev pkg-config bc netpbm debootstrap dpkg-dev
 
-# Clone repository for image creation 
+# Clone repository for image creation
 git clone https://github.com/bleuchtang/sunxi-debian /opt/sunxi-debian


### PR DESCRIPTION
This patch remove whitespaces, and factorise apt-get options in order to reuse it in all apt-get calls.
