### PR TITLE
script: First run - Clean old mysql rules, and generate a new root password

### DIFF
--- a/build/script/firstrun
+++ b/build/script/firstrun
@@ -11,8 +11,21 @@ echo "# update ssh key #"
 echo "##################"
 echo ""
 rm -f /etc/ssh/ssh_host*
-/usr/sbin/dpkg-reconfigure openssh-server 
+/usr/sbin/dpkg-reconfigure openssh-server
 /bin/systemctl disable firstrun
+echo ""
+echo "#########################"
+echo "# update mysql password #"
+echo "#########################"
+echo ""
+[[ $(/bin/ps aux | /bin/grep '[m]ysqld') == "0" ]] && /bin/systemctl start mysql
+# Clean old rules from https://github.com/YunoHost/install_script/blob/master/install_yunohostv2#L210-L211
+echo "delete from user where password=PASSWORD('yunohost');" | /usr/bin/mysql -u root -p"$(cat /etc/yunohost/mysql)" mysql
+# Regenerate a unique https://github.com/YunoHost/yunohost/blob/unstable/data/hooks/conf_regen/34-mysql#L32
+mysql_password=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+/usr/bin/mysqladmin -u root -pyunohost password "$mysql_password"
+/bin/echo "$mysql_password" | /usr/bin/tee /etc/yunohost/mysql
+/bin/chmod 400 /etc/yunohost/mysql
 if [ ! -e /etc/crypttab ]; then
   echo ""
   echo "############################"


### PR DESCRIPTION
This pull-request is related to issue https://dev.yunohost.org/issues/138

Clean default mysql rules (for root user with 127.0.0.1 ::1 and
yunohost.yunohost.org), related to debconf default configuration,
https://github.com/YunoHost/install_script/blob/master/install_yunohostv2#L210-L211

Generate a random mysql password for root user during the first run
and update it for yunohost, for the moment the root MySQL password is
the same on all internetcubes (this password is generated during
package installation)
https://github.com/YunoHost/yunohost/blob/unstable/data/hooks/conf_regen/34-mysql#L32

Closes: #138
