### PR TITLE
Fixes around the passphrase handling in encrypted rootfs boot webserver

### DIFF
--- a/build/script/initramfs/www/cgi-bin/post.sh
+++ b/build/script/initramfs/www/cgi-bin/post.sh
@@ -1,9 +1,22 @@
 #!/bin/sh
 
 read QUERY_STRING
-eval $(echo "$QUERY_STRING" | awk -F'&' '{for(i=1; i <= NF; i++) { print $i }}')
 
-echo -n $(httpd -d $passphrase) > /lib/cryptsetup/passfifo
+# We now split the query string at '&' then each part at '='
+# We look for the X in a=b&passphrase=X&c=d
+passphrase_urlenc=$(echo "$QUERY_STRING" | awk -F'&'   \
+  '{                                                   \
+    for(i=1; i <= NF; i++) {                           \
+      n = split($i, array, "=");                       \
+      if(n == 2 && index(array[1], "passphrase")) {    \
+        print array[2];                                \
+        break;                                         \
+      }                                                \
+    }                                                  \
+  }'                                                   \
+)
+
+echo -n $(httpd -d "$passphrase_urlenc") > /lib/cryptsetup/passfifo
 
 for i in $(seq 30); do
   sleep 1

--- a/build/script/initramfs/www/index.html
+++ b/build/script/initramfs/www/index.html
@@ -230,7 +230,7 @@
         }
       }
 
-      xmlHttp.send('passphrase=' + document.getElementById('passphrase').value);
+      xmlHttp.send('passphrase=' + encodeURIComponent(document.getElementById('passphrase').value));
 
       return false;
     }


### PR DESCRIPTION
This commit ensure that the passphrase is URLencoded in JS-enabled browser as it is in JS-disabled browser (ie. NoScript).
