### PR TITLE
[enh] Restore from an usb key

### DIFF
--- a/build/script/hypercube/hypercube.sh
+++ b/build/script/hypercube/hypercube.sh
@@ -695,6 +695,9 @@ else
       exit_error "Cannot continue without a usable HyperCube or backup file"
     fi
 
+    info "Upgrading Debian/YunoHost..."
+    deb_upgrade
+
     info "Restoring"
     restore
  

--- a/build/script/hypercube/hypercube.sh
+++ b/build/script/hypercube/hypercube.sh
@@ -231,7 +231,7 @@ function restore() {
 
   mv "${backup_file}" "${archive_dir}"
 
-  yunohost backup restore -n backup --verbose &>> $log_file
+  yunohost backup restore -n backup --force --verbose &>> $log_file
 }
 
 function load_json() {

--- a/build/script/hypercube/hypercube.sh
+++ b/build/script/hypercube/hypercube.sh
@@ -697,6 +697,16 @@ else
 
     info "Restoring"
     restore
+ 
+    info "Rebooting..."
+
+    if [ -f /etc/crypttab ]; then
+      warn "Once rebooted, you have to give the passphrase for uncrypting your Cube"
+    fi
+
+    sleep 5
+    keep_debugging=false
+    systemctl reboot
   fi
   
   info "Loading JSON"


### PR DESCRIPTION
## The problem

When users need to restore their system (after an sd card failure), there is no reinstall process.

## Solution

This pr change the hypercube.sh to search a "backup.tar.gz" in /root or in a usb key, if it found one, it try to restore it with "yunohost backup restore" command.

## PR Status

Untested, i have no internetcube here.

Todo:
- [ ] Add a hook in doctorcube to backup and restore /etc/hosts, /etc/environment, hostnamectl, AND CHANGE DEFAULT ROOT PASSWORD

COULDN'T BE RELEASED WITHOUT a solution to replace root default password

## How to test

1. Use install-sd.sh to flash the internetcube image without install.hypercube and using the -w options to replace the hypercube.sh by the one of this PR 'bash install-sd.sh -w THIS/PATH/TO/hypercube.sh'
2. Put your backup tar.gz on an usb stick
3. Call it backup.tar.gz (it's an hardcoded name)
4. Plug your usb stick
5. Power on your internet cube
6. wait and try to reach the debug page (as for install)

## Validation

- [x] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
