### PR TITLE
Doctor Cube aint really needed anymore ?

### DIFF
--- a/build/script/hypercube/hypercube.sh
+++ b/build/script/hypercube/hypercube.sh
@@ -421,12 +421,6 @@ function install_webmail() {
   }
 }
 
-function install_doctorcube() {
-  logfile ${FUNCNAME[0]}
-
-  yunohost app install doctorcube --debug &>> $log_file
-}
-
 function configure_hotspot() {
   logfile ${FUNCNAME[0]}
   local ynh_wifi_device=
@@ -752,9 +746,6 @@ else
   
   info "Installing Wifi Hotspot..."
   install_hotspot
-
-  info "Installing DoctorCube..."
-  install_doctorcube
 
   info "Installing Roundcube Webmail..."
   install_webmail || true


### PR DESCRIPTION
This is a proposal to remove doctor cube from the new install procedure, as imho it's not needed anymore. This stuff is already integrated in YunoHost now or refers to old technical issues.

For the future : I don't see how an issue can be specific to the Internet Cube and not to YunoHost, especially if Internet Cube images are based on YunoHost. If this is an app issue (vpn / hotspot) then it should be adressed via a regular app upgrade. If it's an hardware issue, then it's also related to other, "non-internetcube" setups on this hardware and should be adressed appropriately in an agnostic way (e.g. a yunohost migration targetting this hardware).