### PR TITLE
This is the community list, so we should call the list community ?

### DIFF
--- a/build/script/hypercube/hypercube.sh
+++ b/build/script/hypercube/hypercube.sh
@@ -329,7 +329,7 @@ function ynh_postinstall() {
 function ynh_addappslist() {
   logfile ${FUNCNAME[0]}
 
-  yunohost app fetchlist -n labriqueinternet -u https://app.yunohost.org/community.json --verbose &>> $log_file
+  yunohost app fetchlist -n community -u https://app.yunohost.org/community.json --verbose &>> $log_file
   yunohost app fetchlist --verbose &>> $log_file
 }
 


### PR DESCRIPTION
c.f. https://github.com/labriqueinternet/build.labriqueinter.net/pull/44

Wouldn't it be better to rename this 'community' ?