### PR TITLE
Fix labriqueinternet/build.labriqueinter.net#47 removing unnecessary umount

### DIFF
--- a/build/create_arm_debootstrap.sh
+++ b/build/create_arm_debootstrap.sh
@@ -248,7 +248,6 @@ if [ $ENCRYPT ] ; then
   echo 'deb http://ftp.fr.debian.org/debian jessie-backports main' > $TARGET_DIR/etc/apt/sources.list.d/jessie-backports.list
 fi
 
-umount_dir $TARGET_DIR
 chroot_deb $TARGET_DIR 'apt-get update'
 chroot_deb $TARGET_DIR 'apt-get upgrade -y --force-yes'
 


### PR DESCRIPTION
Calling `umount_dir` before installing `stunnel4` make apt to fail labriqueinternet/build.labriqueinter.net#47. 

The `umount_dir` function is already called when the script finishes:
```
finish(){
   umount_dir $TARGET_DIR 
}
trap finish EXIT
```