### PR TITLE
Don't process backslashes in json values

### DIFF
--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -240,7 +240,7 @@ function load_json() {
 function extract_settings() {
   logfile "${FUNCNAME[0]}-${1}"
 
-  local subjson=$(echo -e "${json}" | grep "^${1}=" | cut -d= -f2-)
+  local subjson=$(echo "${json}" | grep "^${1}=" | cut -d= -f2-)
   local vars=$(echo "${subjson}" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' 2>> $log_file)
 
   if [ -z "$vars" ]; then
@@ -262,7 +262,7 @@ function extract_settings() {
 }
 
 function extract_dotcube() {
-  local subjson=$(echo -e "${json}" | grep "^vpnclient=" | cut -d= -f2-)
+  local subjson=$(echo "${json}" | grep "^vpnclient=" | cut -d= -f2-)
 
   if [ -z "$subjson" ]; then
     exit_error "vpnclient settings not found"


### PR DESCRIPTION
This fixes a bug when install.hypercube file contains values with backslashes. For instance : 
```json
"unix": {
    "root_password": "B2V'MIF+%/\\Ig81SM<Q",
    "lang": "en"
}
```
I tested my changes on a cube, and it worked fine.