### PR TITLE
Execute custom script

### DIFF
--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -764,7 +764,7 @@ else
   info "Configuring Wifi Hotspot..."
   configure_hotspot
  
-  if [ -f "${log_filepath}/execute_custom_script" ]; then
+  if [ -f "/usr/local/bin/hypercube_custom.sh" ]; then
     info "Execute custom script..."
     /usr/local/bin/hypercube_custom.sh
   fi

--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -764,6 +764,11 @@ else
   info "Configuring Wifi Hotspot..."
   configure_hotspot
  
+  if [ -f "${log_filepath}/execute_custom_script" ]; then
+    info "Execute custom script..."
+    /usr/local/bin/hypercube_custom.sh
+  fi
+
   info "Rebooting..."
 
   if [ -f /etc/crypttab ]; then

--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -457,6 +457,12 @@ function configure_vpnclient() {
   ynh-vpnclient-loadcubefile.sh -u "${settings[yunohost,user]}" -p "${settings[yunohost,user_password]}" -c "${tmp_dir}/config.cube" &>> $log_file || true
 }
 
+function execute_customscript() {
+  logfile ${FUNCNAME[0]}
+
+  bash "$custom_script" &>> $log_file
+}
+
 function monitoring_ip() {
   logfile ${FUNCNAME[0]}
   set +E
@@ -623,6 +629,7 @@ function end_installation() {
 declare -A settings
 tmp_dir=$(mktemp -dp /tmp/ labriqueinternet-installhypercube-XXXXX)
 hypercube_file="${tmp_dir}/install.hypercube"
+custom_script="/usr/local/bin/hypercube_custom.sh"
 exit_status=0
 webserver_pid=
 is_dyndns_useful=false
@@ -764,9 +771,9 @@ else
   info "Configuring Wifi Hotspot..."
   configure_hotspot
  
-  if [ -f "/usr/local/bin/hypercube_custom.sh" ]; then
+  if [ -f "$custom_script" ]; then
     info "Execute custom script..."
-    /usr/local/bin/hypercube_custom.sh
+    execute_customscript
   fi
 
   info "Rebooting..."


### PR DESCRIPTION
As explained in the issue https://github.com/labriqueinternet/build.labriqueinter.net/issues/64, these changes allow to execute a custom script at the end of the execution of the `hypercube.sh`. With these changes, I could built and install an image with and without a custom script. I did my test using the `install-sd.sh` of [this branch](https://github.com/SohKa/labriqueinter.net/tree/execute-custom-script).