### PR TITLE
Add option to not install hotspot app

### DIFF
--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -416,8 +416,8 @@ function install_vpnclient() {
 function install_hotspot() {
   logfile ${FUNCNAME[0]}
 
-  if [ "${settings[hotspot,do_not_install]}" == yes ]; then
-    touch "${log_filepath}/do_not_install_hotspot"
+  if [[ ${settings[hotspot,enabled]} == false ]]; then
+    touch "${log_filepath}/hotspot_disabled"
     echo "The hotspot app won't be installed as set in the hypercube file" >> $log_file
   else
     yunohost app install hotspot --force --debug\

--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -507,7 +507,7 @@ function monitoring_ip() {
     echo TRACEROUTE 91.198.174.192 >> $tmplog
     echo ================= >> $tmplog
     traceroute -n 91.198.174.192 &>> $tmplog
-    if [ ! -f "${log_filepath}/do_not_install_hotspot" ]; then
+    if [ ! -f "${log_filepath}/hotspot_disabled" ]; then
       echo -e "\n\n" >> $tmplog
       echo IW DEV >> $tmplog
       echo ================= >> $tmplog
@@ -557,7 +557,7 @@ function monitoring_processes() {
     echo YNH-VPNCLIENT STATUS >> $tmplog
     echo ================= >> $tmplog
     ynh-vpnclient status &>> $tmplog
-    if [ ! -f "${log_filepath}/do_not_install_hotspot" ]; then
+    if [ ! -f "${log_filepath}/hotspot_disabled" ]; then
       echo -e "\n\n" >> $tmplog
       echo YNH-HOTSPOT STATUS >> $tmplog
       echo ================= >> $tmplog
@@ -571,7 +571,7 @@ function monitoring_processes() {
     echo 'PS AUX | GREP DNSMASQ' >> $tmplog
     echo ================= >> $tmplog
     ps aux | grep dnsmasq &>> $tmplog
-    if [ ! -f "${log_filepath}/do_not_install_hotspot" ]; then
+    if [ ! -f "${log_filepath}/hotspot_disabled" ]; then
       echo -e "\n\n" >> $tmplog
       echo 'PS AUX | GREP HOSTAPD' >> $tmplog
       echo ================= >> $tmplog
@@ -606,7 +606,7 @@ function monitoring_yunohost() {
 function end_installation() {
   log_fileindex=90
 
-  if [ ! -f "${log_filepath}/do_not_install_hotspot" ]; then
+  if [ ! -f "${log_filepath}/hotspot_disabled" ]; then
     detect_wifidevice
   fi
 
@@ -769,7 +769,7 @@ else
   info "Configuring VPN Client..."
   configure_vpnclient
   
-  if [ ! -f "${log_filepath}/do_not_install_hotspot" ]; then
+  if [ ! -f "${log_filepath}/hotspot_disabled" ]; then
     info "Configuring Wifi Hotspot..."
     configure_hotspot
   fi


### PR DESCRIPTION
Some people (like me) don't use the hotspot app. It is then a waste of time to install it during the hypercube script execution and to manually remove it afterwards.

With this pull request, the user will just have to set the key-value pairs `"enabled": "false"` inside the `hotspot` dictionary in the hypercube file and the hotspot app won't be installed.
```json
"hotspot": {
  "enabled": "false"
}
```

Edit : [as suggested by](https://github.com/labriqueinternet/build.labriqueinter.net/pull/69#discussion_r405799118) @hidrarga, I modified the key-value pairs to be a bit more intuitive. 