### PR TITLE
Fix traceroute commands

### DIFF
--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -201,7 +201,7 @@ function find_hypercubefile() {
   apt-get clean &>> $log_file
   apt-get update &>> $log_file
 
-  apt-get install -o Dpkg::Options::='--force-confold' -y --force-yes file udisks2 udiskie ntfs-3g jq  &>> $log_file || true
+  apt-get install -o Dpkg::Options::='--force-confold' -y --force-yes file udisks2 udiskie ntfs-3g jq traceroute  &>> $log_file || true
   
   info "Detecting USB sticks..."
   udiskie-mount -a || true


### PR DESCRIPTION
Hello !

At the end of the cube installation, at the `MONITORING_IP` step, the `hypercube.sh` script can't execute the traceroute commands : 
```
TRACEROUTE 2XXX:XXXX:XXXX:XXXX::XXXX
=================
/usr/local/bin/hypercube.sh: line 505: traceroute6: command not found

TRACEROUTE 91.XXX.XXX.XXX
=================
/usr/local/bin/hypercube.sh: line 509: traceroute: command not found
```

Originally, I think the traceroute commands were provided by the `net-tools` package. As it's no longer the case, it is necessary to install the `traceroute` package (for the `traceroute` and `traceroute6` commands).