### PR TITLE
change hypercube systemd service type to get it in active state at start

### DIFF
--- a/script/hypercube/hypercube.service
+++ b/script/hypercube/hypercube.service
@@ -4,7 +4,7 @@ Requires=network.target
 After=network.target dnsmasq.service ynh-hotspot.service ynh-vpnclient.service resize2fs-reboot.service firstrun.service secondrun.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/local/bin/hypercube.sh
 RemainAfterExit=no
 


### PR DESCRIPTION
Hi !

I was doing some experiments with the `hypercube.sh` script and I noticed its systemd service never goes in active state. The reason is : because the service unit is of the oneshot type, the state is `activating (start)`  during the execution (once it has successfully ran, it directly goes to `inactive (dead)`). 

But I can not find a reason for this. No service needs to wait for it to finish its execution before being started (like the `hypercube.sh` depends on `firstrun.service` and `secondrun.service`) since it does the cube's setup until the end. Plus, since it provides a web server (`SimpleHTTPServer`), I think the `hypercube.sh` script isn't just a regular one-task shell script.

Thus, I think the type `simple` (as set in this PR) would be more convenient for this service.

I tested this change by reinstalling from scratch my lime2.