### PR TITLE
No need to feed the ldap/admin password anymore

### DIFF
--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -403,7 +403,7 @@ function ynh_createuser() {
 
   yunohost user create "${settings[yunohost,user]}" -f "${settings[yunohost,user_firstname]}"\
     -l "${settings[yunohost,user_lastname]}" -m "${settings[yunohost,user]}@${settings[yunohost,domain]}"\
-    -q 0 -p "${settings[yunohost,user_password]}" --admin-password "${settings[yunohost,password]}" --debug |& logfilter
+    -q 0 -p "${settings[yunohost,user_password]}" --debug |& logfilter
 }
 
 function install_vpnclient() {


### PR DESCRIPTION
It's been a long time it's not needed and may get removed in https://github.com/YunoHost/yunohost/pull/922