### PR TITLE
[fix] revert the disabling of the debian upgrade function

### DIFF
--- a/script/hypercube/hypercube.sh
+++ b/script/hypercube/hypercube.sh
@@ -719,8 +719,8 @@ else
   info "Setting locales"
   deb_setlocales_and_tz
 
-  #info "Upgrading Debian/YunoHost..."
-  #deb_upgrade
+  info "Upgrading Debian/YunoHost..."
+  deb_upgrade
 
   info "Check online DynDNS domains list"
   check_dyndns_list


### PR DESCRIPTION
Hi !

It was too early [to disable the execution](https://github.com/labriqueinternet/build.labriqueinter.net/commit/4f817c3f0ddae6503fa49afad042e39742cf8470#diff-bcd75a04a8e5eba5122af1504ac75c1eR713) of the `deb_upgrade` function since the CI for the image building doesn't seem to be ready yet.

If one tries to build an image with the current scripts, the execution of the `hypercube.sh` script will fail (at multiple points) because the version of the Yunohost packages is too old.

For example, it will fail because [this change](https://github.com/labriqueinternet/build.labriqueinter.net/pull/72/files) needs a more recent version. It will also fail at the vpnclient installation step because this old version of Yunohost depends of the [adding of the old community app list](https://github.com/labriqueinternet/build.labriqueinter.net/pull/68/files#diff-bcd75a04a8e5eba5122af1504ac75c1eL361).

IMHO, we should revert this change.

